### PR TITLE
Add endpoint for assigning pincodes to an outlet with validation

### DIFF
--- a/dtos/outlet_request_dto.go
+++ b/dtos/outlet_request_dto.go
@@ -9,3 +9,7 @@ type Outlet struct {
 	Website     string `json:"website" example:"attingal.superstore.com"`
 	Status      string `json:"status" example:"active"`
 }
+
+type OutletPincodes struct {
+	Pincodes []string `json:"pincodes" example:"["695606", 695101", "695103"]"`
+}

--- a/handlers/outlet/outlet_handler.go
+++ b/handlers/outlet/outlet_handler.go
@@ -186,7 +186,7 @@ func GetOutlet(c *gin.Context) {
 // @Tags         Outlet
 // @Accept       json
 // @Produce      json
-// @Param        pincodes  body  dtos.OutletServicePincode  true  "Service Pincodes"
+// @Param        pincodes  body  dtos.OutletPincodes  true  "Service Pincodes"
 // @Success      200  {object}  dtos.SuccessResponse
 // @Failure      500  {object}  dtos.ErrorResponse
 // @Security BearerAuth

--- a/routes/router.go
+++ b/routes/router.go
@@ -30,6 +30,7 @@ func Intiliaze(r *gin.Engine) {
 	outletRoutes.PUT("/:id/assign-manager", outletHandler.AssignManager)
 	outletRoutes.GET("", outletHandler.GetOutlets)
 	outletRoutes.GET("/:id", outletHandler.GetOutlet)
+	outletRoutes.POST("/:id/assign-pincodes", outletHandler.AssignOutletServicePincode)
 
 	employeeRoutes := api.Group("/employee")
 	employeeRoutes.Use(auth.JWTMiddleware())


### PR DESCRIPTION
Introduce a new endpoint to assign service area pincodes to an outlet, including validation for input and response handling. Update the DTO for Swagger documentation.